### PR TITLE
Fix test DbContext mismatch

### DIFF
--- a/tests/CharityPay.API.Tests/Integration/ApiTestFixture.cs
+++ b/tests/CharityPay.API.Tests/Integration/ApiTestFixture.cs
@@ -57,14 +57,14 @@ public class CharityPayWebApplicationFactory : WebApplicationFactory<Program>, I
         builder.ConfigureServices(services =>
         {
             // Remove the existing DbContext registration
-            var descriptor = services.SingleOrDefault(d => d.ServiceType == typeof(DbContextOptions<ApplicationDbContext>));
+            var descriptor = services.SingleOrDefault(d => d.ServiceType == typeof(DbContextOptions<CharityPayDbContext>));
             if (descriptor != null)
             {
                 services.Remove(descriptor);
             }
 
             // Add test database context
-            services.AddDbContext<ApplicationDbContext>(options =>
+            services.AddDbContext<CharityPayDbContext>(options =>
                 options.UseNpgsql(ConnectionString));
 
             // Configure logging for tests
@@ -127,7 +127,7 @@ public class ApiTestFixture : IAsyncLifetime
 
         // Apply migrations and seed initial data
         using var scope = _factory.CreateScope();
-        var context = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var context = scope.ServiceProvider.GetRequiredService<CharityPayDbContext>();
         await context.Database.MigrateAsync();
         await SeedTestDataAsync(context);
     }
@@ -144,7 +144,7 @@ public class ApiTestFixture : IAsyncLifetime
     /// <summary>
     /// Seeds the database with test data for API testing
     /// </summary>
-    private async Task SeedTestDataAsync(ApplicationDbContext context)
+    private async Task SeedTestDataAsync(CharityPayDbContext context)
     {
         // Create admin user
         var adminUser = TestDataBuilders.User()
@@ -300,7 +300,7 @@ public class ApiTestFixture : IAsyncLifetime
     public async Task ClearDatabaseAsync()
     {
         using var scope = _factory.CreateScope();
-        var context = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var context = scope.ServiceProvider.GetRequiredService<CharityPayDbContext>();
         
         context.Payments.RemoveRange(context.Payments);
         context.Organizations.RemoveRange(context.Organizations);
@@ -312,10 +312,10 @@ public class ApiTestFixture : IAsyncLifetime
     /// <summary>
     /// Gets the database context for direct database operations in tests
     /// </summary>
-    public ApplicationDbContext GetDbContext()
+    public CharityPayDbContext GetDbContext()
     {
         var scope = _factory.CreateScope();
-        return scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        return scope.ServiceProvider.GetRequiredService<CharityPayDbContext>();
     }
 }
 

--- a/tests/CharityPay.Application.Tests/Fixtures/TestFixture.cs
+++ b/tests/CharityPay.Application.Tests/Fixtures/TestFixture.cs
@@ -1,7 +1,6 @@
 using AutoMapper;
 using CharityPay.Application.Mappings;
 using CharityPay.Application.Services;
-using CharityPay.Application.Services.Interfaces;
 using CharityPay.Domain.Tests.Builders;
 using CharityPay.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
@@ -18,7 +17,7 @@ namespace CharityPay.Application.Tests.Fixtures;
 public class ApplicationTestFixture : IDisposable
 {
     public IServiceProvider ServiceProvider { get; }
-    public ApplicationDbContext DbContext { get; }
+    public CharityPayDbContext DbContext { get; }
     public IMapper Mapper { get; }
 
     public ApplicationTestFixture()
@@ -26,7 +25,7 @@ public class ApplicationTestFixture : IDisposable
         var services = new ServiceCollection();
         
         // Add in-memory database
-        services.AddDbContext<ApplicationDbContext>(options =>
+        services.AddDbContext<CharityPayDbContext>(options =>
             options.UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString()));
 
         // Add AutoMapper
@@ -39,7 +38,7 @@ public class ApplicationTestFixture : IDisposable
         ServiceProvider = services.BuildServiceProvider();
         
         // Get instances
-        DbContext = ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        DbContext = ServiceProvider.GetRequiredService<CharityPayDbContext>();
         Mapper = ServiceProvider.GetRequiredService<IMapper>();
 
         // Ensure database is created
@@ -119,7 +118,7 @@ public class ApplicationTestCollection : ICollectionFixture<ApplicationTestFixtu
 public abstract class ApplicationTestBase : IAsyncLifetime
 {
     protected readonly ApplicationTestFixture Fixture;
-    protected readonly ApplicationDbContext DbContext;
+    protected readonly CharityPayDbContext DbContext;
     protected readonly IMapper Mapper;
 
     protected ApplicationTestBase(ApplicationTestFixture fixture)
@@ -170,7 +169,7 @@ public class ServiceTestHelper
     /// Creates an OrganizationService with mocked dependencies for testing
     /// </summary>
     public static OrganizationService CreateOrganizationService(
-        ApplicationDbContext context,
+        CharityPayDbContext context,
         IMapper mapper,
         ILogger<OrganizationService> logger = null)
     {
@@ -182,7 +181,7 @@ public class ServiceTestHelper
     /// Creates a PaymentService with mocked dependencies for testing
     /// </summary>
     public static PaymentService CreatePaymentService(
-        ApplicationDbContext context,
+        CharityPayDbContext context,
         IMapper mapper,
         ILogger<PaymentService> logger = null)
     {
@@ -194,7 +193,7 @@ public class ServiceTestHelper
     /// Creates an AuthenticationService with mocked dependencies for testing
     /// </summary>
     public static AuthenticationService CreateAuthenticationService(
-        ApplicationDbContext context,
+        CharityPayDbContext context,
         IPasswordService passwordService = null,
         IJwtService jwtService = null,
         ILogger<AuthenticationService> logger = null)

--- a/tests/CharityPay.Infrastructure.Tests/Integration/DatabaseTestFixture.cs
+++ b/tests/CharityPay.Infrastructure.Tests/Integration/DatabaseTestFixture.cs
@@ -16,7 +16,7 @@ public class DatabaseTestFixture : IAsyncLifetime
     private readonly PostgreSqlContainer _postgres;
     private IServiceProvider _serviceProvider;
 
-    public ApplicationDbContext DbContext { get; private set; }
+    public CharityPayDbContext DbContext { get; private set; }
     public string ConnectionString { get; private set; }
 
     public DatabaseTestFixture()
@@ -50,7 +50,7 @@ public class DatabaseTestFixture : IAsyncLifetime
         services.AddSingleton<IConfiguration>(configuration);
 
         // Add DbContext with real PostgreSQL
-        services.AddDbContext<ApplicationDbContext>(options =>
+        services.AddDbContext<CharityPayDbContext>(options =>
             options.UseNpgsql(ConnectionString));
 
         // Add logging
@@ -61,7 +61,7 @@ public class DatabaseTestFixture : IAsyncLifetime
         });
 
         _serviceProvider = services.BuildServiceProvider();
-        DbContext = _serviceProvider.GetRequiredService<ApplicationDbContext>();
+        DbContext = _serviceProvider.GetRequiredService<CharityPayDbContext>();
 
         // Apply migrations
         await DbContext.Database.MigrateAsync();
@@ -136,7 +136,7 @@ public class DatabaseTestCollection : ICollectionFixture<DatabaseTestFixture>
 public abstract class DatabaseTestBase : IAsyncLifetime
 {
     protected readonly DatabaseTestFixture Fixture;
-    protected readonly ApplicationDbContext DbContext;
+    protected readonly CharityPayDbContext DbContext;
 
     protected DatabaseTestBase(DatabaseTestFixture fixture)
     {
@@ -157,7 +157,7 @@ public abstract class DatabaseTestBase : IAsyncLifetime
     /// <summary>
     /// Executes a function within a database transaction that is rolled back
     /// </summary>
-    protected async Task<T> ExecuteInTransactionAsync<T>(Func<ApplicationDbContext, Task<T>> action)
+    protected async Task<T> ExecuteInTransactionAsync<T>(Func<CharityPayDbContext, Task<T>> action)
     {
         using var transaction = await DbContext.Database.BeginTransactionAsync();
         try
@@ -176,7 +176,7 @@ public abstract class DatabaseTestBase : IAsyncLifetime
     /// <summary>
     /// Executes an action within a database transaction that is rolled back
     /// </summary>
-    protected async Task ExecuteInTransactionAsync(Func<ApplicationDbContext, Task> action)
+    protected async Task ExecuteInTransactionAsync(Func<CharityPayDbContext, Task> action)
     {
         using var transaction = await DbContext.Database.BeginTransactionAsync();
         try
@@ -229,7 +229,7 @@ public class DatabasePerformanceFixture : DatabaseTestFixture
     /// <summary>
     /// Measures the execution time of a database operation
     /// </summary>
-    public async Task<T> MeasureAsync<T>(Func<ApplicationDbContext, Task<T>> operation, string operationName = null)
+    public async Task<T> MeasureAsync<T>(Func<CharityPayDbContext, Task<T>> operation, string operationName = null)
     {
         var stopwatch = System.Diagnostics.Stopwatch.StartNew();
         var result = await operation(DbContext);
@@ -275,7 +275,7 @@ public static class DatabaseTestDataHelper
     /// <summary>
     /// Seeds the database with a realistic test dataset
     /// </summary>
-    public static async Task SeedRealisticDataAsync(ApplicationDbContext context)
+    public static async Task SeedRealisticDataAsync(CharityPayDbContext context)
     {
         // Create admin user
         var adminUser = CharityPay.Domain.Tests.Builders.TestDataBuilders.User()
@@ -325,7 +325,7 @@ public static class DatabaseTestDataHelper
     /// <summary>
     /// Creates a large dataset for performance testing
     /// </summary>
-    public static async Task SeedLargeDatasetAsync(ApplicationDbContext context, int organizationCount = 100, int paymentsPerOrg = 50)
+    public static async Task SeedLargeDatasetAsync(CharityPayDbContext context, int organizationCount = 100, int paymentsPerOrg = 50)
     {
         // Create organizations in batches
         const int batchSize = 20;


### PR DESCRIPTION
## Summary
- update test fixtures to use `CharityPayDbContext`
- remove old `ApplicationDbContext` references
- fix stray namespace reference in application tests

## Testing
- `dotnet test --no-build` *(fails: The argument ... net9.0)*

------
https://chatgpt.com/codex/tasks/task_b_6876cbaaa12c8322b851fea70b1b3897